### PR TITLE
Clean up output when mesh0 is missing

### DIFF
--- a/scripts/status
+++ b/scripts/status
@@ -10,7 +10,7 @@ echo "  | || (_) | | | | | |  __\__ | | | |"
 echo "   \__\___/|_| |_| |_|\___|___|_| |_|"
 
 echo -e '---------------------------------------'
-if [ "$(iw dev mesh0 info | grep 'type mesh point')" ] && [ "$(iw dev mesh0 info | grep 'channel')" ]; then
+if [ "$(iw dev mesh0 info 2>/dev/null | grep 'type mesh point')" ] && [ "$(iw dev mesh0 info 2>/dev/null | grep 'channel')" ]; then
         echo -e "Mesh Interface ............... $ACTIVE"
 else
         echo -e "Mesh Interface ............. $INACTIVE"


### PR DESCRIPTION
```
pi@raspberrypi:~ $ source prototype-cjdns-pi2/scripts/status
   _                           _
  | |_ ___  _ __ ___   ___ ___| |__
  | __/ _ \| '_ ` _ \ / _ / __| '_ \
  | || (_) | | | | | |  __\__ | | | |
   \__\___/|_| |_| |_|\___|___|_| |_|
---------------------------------------
command failed: No such device (-19) <-- Getting rid of this
Mesh Interface ............. [INACTIVE]
cjdns Service ................ [ACTIVE]
```
