### PR TITLE
Automatically install NodeJS on ArmV6

### DIFF
--- a/scripts/install2
+++ b/scripts/install2
@@ -85,6 +85,7 @@ if ! [ "$(which nodejs)" ]; then
 pwd
         wget -O /tmp/node-v6.11.0-linux-armv6l.tar.gz https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv6l.tar.gz
         sudo tar xvfz /tmp/node-v6.11.0-linux-armv6l.tar.gz --strip 1 -C /
+	rm -rf /tmp/node-v6.11.0-linux-armv6l.tar.gz
         ln -s /bin/node /bin/nodejs
     else
        curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -

--- a/scripts/install2
+++ b/scripts/install2
@@ -84,9 +84,9 @@ if ! [ "$(which nodejs)" ]; then
     if $(uname -m | grep -Eq ^armv6); then
 pwd
         wget -O /tmp/node-v6.11.0-linux-armv6l.tar.gz https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv6l.tar.gz
-        sudo tar xvfz /tmp/node-v6.11.0-linux-armv6l.tar.gz --strip 1 -C /
+        sudo tar xfz /tmp/node-v6.11.0-linux-armv6l.tar.gz --strip 1 -C /
 	rm -rf /tmp/node-v6.11.0-linux-armv6l.tar.gz
-        ln -s /bin/node /bin/nodejs
+        sudo ln -s /bin/node /bin/nodejs
     else
        curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
        sudo apt-get install nodejs -y

--- a/scripts/install2
+++ b/scripts/install2
@@ -79,10 +79,18 @@ fi
 
 # Get tools
 if ! [ "$(which nodejs)" ]; then
-    curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
-    sudo apt-get install nodejs -y
-fi
 
+#check for armv6 and install it manually instead
+    if $(uname -m | grep -Eq ^armv6); then
+        wget https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv6l.tar.gz
+        sudo tar xvfz ../node-v6.11.0-linux-armv6l.tar.gz --strip 1 -C /
+        ln -s /bin/node /bin/nodejs
+    else
+       curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
+       sudo apt-get install nodejs -y
+   fi
+
+fie
 # Download cjdns repo and checkout TAG_CJDNS tag
 if ! [ -d "/opt/cjdns" ]; then
     here=`pwd`

--- a/scripts/install2
+++ b/scripts/install2
@@ -82,10 +82,9 @@ if ! [ "$(which nodejs)" ]; then
 
 #check for armv6 and install it manually instead
     if $(uname -m | grep -Eq ^armv6); then
-pwd
         wget -O /tmp/node-v6.11.0-linux-armv6l.tar.gz https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv6l.tar.gz
         sudo tar xfz /tmp/node-v6.11.0-linux-armv6l.tar.gz --strip 1 -C /
-	rm -rf /tmp/node-v6.11.0-linux-armv6l.tar.gz
+        rm -rf /tmp/node-v6.11.0-linux-armv6l.tar.gz
         sudo ln -s /bin/node /bin/nodejs
     else
        curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -

--- a/scripts/install2
+++ b/scripts/install2
@@ -90,7 +90,7 @@ if ! [ "$(which nodejs)" ]; then
        sudo apt-get install nodejs -y
    fi
 
-fie
+fi
 # Download cjdns repo and checkout TAG_CJDNS tag
 if ! [ -d "/opt/cjdns" ]; then
     here=`pwd`

--- a/scripts/install2
+++ b/scripts/install2
@@ -82,8 +82,9 @@ if ! [ "$(which nodejs)" ]; then
 
 #check for armv6 and install it manually instead
     if $(uname -m | grep -Eq ^armv6); then
-        wget https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv6l.tar.gz
-        sudo tar xvfz ../node-v6.11.0-linux-armv6l.tar.gz --strip 1 -C /
+pwd
+        wget -O /tmp/node-v6.11.0-linux-armv6l.tar.gz https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv6l.tar.gz
+        sudo tar xvfz /tmp/node-v6.11.0-linux-armv6l.tar.gz --strip 1 -C /
         ln -s /bin/node /bin/nodejs
     else
        curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -

--- a/scripts/install2
+++ b/scripts/install2
@@ -80,7 +80,7 @@ fi
 # Get tools
 if ! [ "$(which nodejs)" ]; then
 
-#check for armv6 and install it manually instead
+    #Check for armv6 and install nodejs manually instead since it will not install via repo
     if $(uname -m | grep -Eq ^armv6); then
         wget -O /tmp/node-v6.11.0-linux-armv6l.tar.gz https://nodejs.org/dist/v6.11.0/node-v6.11.0-linux-armv6l.tar.gz
         sudo tar xfz /tmp/node-v6.11.0-linux-armv6l.tar.gz --strip 1 -C /


### PR DESCRIPTION
**ISSUE**

When you run the install script on Pi1 install is blocked with following message

`## You appear to be running on ARMv6 hardware. Unfortunately this is not currently supported by the NodeSource Linux distributions. Please use the 'linux-armv6l' binary tarballs available directly from nodejs.org for Node.js v4 and later.
`

**RESOLUTION**

Modifications detect the armv6 processor and if found manually downloads node-v6.11.0-linux-armv6l.tar.gz  from nodejs.org, extracts/installs it then creates a link for binary from node to nodejs .

This allows for the installation to proceed without interruption.