### PR TITLE
Install Process for cjdns

### DIFF
--- a/scripts/install2
+++ b/scripts/install2
@@ -226,13 +226,15 @@ fi
 if ! [ -x "/opt/cjdns/cjdroute" ]; then
     here=`pwd`
     cd /opt/cjdns && eval $CJDNS_BUILD_CMD && cd $here
+    if ! [ -x "/usr/bin/cjdroute" ]; then
+        sudo rm -f /usr/bin/cjdroute
+    fi
 fi
 
 # Install cjdns to /usr/bin
 if ! [ -x "/usr/bin/cjdroute" ]; then
-    rm -rf /usr/bin/cjdroute
+    sudo cp /opt/cjdns/cjdroute /usr/bin/cjdroute
 fi
-sudo cp /opt/cjdns/cjdroute /usr/bin/cjdroute
 
 # Generate cjdns configurations
 if ! [ -f "/etc/cjdroute.conf" ]; then

--- a/scripts/install2
+++ b/scripts/install2
@@ -230,8 +230,9 @@ fi
 
 # Install cjdns to /usr/bin
 if ! [ -x "/usr/bin/cjdroute" ]; then
-    sudo cp /opt/cjdns/cjdroute /usr/bin/cjdroute
+    rm -rf /usr/bin/cjdroute
 fi
+sudo cp /opt/cjdns/cjdroute /usr/bin/cjdroute
 
 # Generate cjdns configurations
 if ! [ -f "/etc/cjdroute.conf" ]; then

--- a/scripts/install2
+++ b/scripts/install2
@@ -60,7 +60,7 @@ if [[ $BOARD_FAMILY == "Orange Pi" ]]; then
                 echo -e "\e[1;32mDowngrading Kernel...\e[0m"
                 wget https://github.com/darkdrgn2k/OrangePiXRadio/raw/master/linux-image-dev-sun8i_5.26_armhf.deb 
                 sudo dpkg -i linux-image-dev-sun8i_5.26_armhf.deb
-                sudo rm -rf linux-image-dev-sun8i_5.26_armhf.deb
+                rm -rf linux-image-dev-sun8i_5.26_armhf.deb
             fi
         fi
     fi

--- a/scripts/install2
+++ b/scripts/install2
@@ -60,7 +60,7 @@ if [[ $BOARD_FAMILY == "Orange Pi" ]]; then
                 echo -e "\e[1;32mDowngrading Kernel...\e[0m"
                 wget https://github.com/darkdrgn2k/OrangePiXRadio/raw/master/linux-image-dev-sun8i_5.26_armhf.deb 
                 sudo dpkg -i linux-image-dev-sun8i_5.26_armhf.deb
-                rm -rf linux-image-dev-sun8i_5.26_armhf.deb
+                sudo rm -rf linux-image-dev-sun8i_5.26_armhf.deb
             fi
         fi
     fi


### PR DESCRIPTION
Currently the build process ignores the newly build cjdns if /usr/bin/cjdroute exists.

This is very confusing if you installed it previously and your banging your head against the wall wondering why the specs are not better with the new patches :)

Patch will remove old cjdns in favor of the newly compiled one