### PR TITLE
IPFS update

### DIFF
--- a/scripts/ipfs/install
+++ b/scripts/ipfs/install
@@ -2,7 +2,7 @@
 
 set -e
 
-GO_IPFS_VERSION=v0.4.15
+GO_IPFS_VERSION=v0.4.17
 
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/scripts/ipfs/ipfs.service
+++ b/scripts/ipfs/ipfs.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 Environment=IPFS_PATH=USER_HOME/.ipfs
-ExecStart=/usr/local/bin/ipfs daemon --enable-namesys-pubsub
+ExecStart=/usr/local/bin/ipfs daemon --enable-namesys-pubsub --migrate=true
 ExecStop=/usr/bin/pkill -f ipfs
 Restart=on-failure
 RestartSec=10s


### PR DESCRIPTION
Changed the IPFS version. The `--migrate=true` flag is required for v0.4.16 as outlined [here](https://github.com/ipfs/go-ipfs/blob/v0.4.17/CHANGELOG.md#0416-2018-07-13) to update existing files and folders on IPFS due to some dht changes.