### PR TITLE
Sudo permission fix

### DIFF
--- a/scripts/ssb-web/install
+++ b/scripts/ssb-web/install
@@ -9,7 +9,9 @@ source "$BASE_DIR/../shared/nginx/install"
 sudo apt-get install -y php-fpm socat
 
 # Install required parts of ssb from npm
-sudo npm install -g --unsafe-perm \
+# sudo sudo is a hack to allow post-install scripts that drop one level of sudo and still be sudoed
+# otherwise you get permissions errors when it tries to write to root owned folders
+sudo sudo npm install -g --unsafe-perm \
                  ssb-keys \
                  ssb-client \
                  ssb-feed \

--- a/scripts/ssb/install
+++ b/scripts/ssb/install
@@ -8,7 +8,9 @@ BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 sudo apt-get install -y socat python-dev libtool python-setuptools autoconf automake
 
 # Install scuttlebot
-sudo npm install scuttlebot -g --unsafe-perm
+# sudo sudo is a hack to allow post-install scripts that drop one level of sudo and still be sudoed
+# otherwise you get permissions errors when it tries to write to root owned folders
+sudo sudo npm install scuttlebot -g --unsafe-perm
 
 # Store current user as sudo will change it
 currentUser=$USER


### PR DESCRIPTION
Fixed issue with permissions during npm install

Solution was to wrapp sudo in another sudo 

Reason is that it seems post-install scripts drop sudo to do their thing and recently started giving permission errors (writing to folders owned by root). Wrapping it in 2 sudos keeps the in a sudoed environment.
