### PR TITLE
Updated meshpoint script to scan all interfaces

### DIFF
--- a/scripts/mesh-point/mesh-point
+++ b/scripts/mesh-point/mesh-point
@@ -6,30 +6,35 @@ function isMeshable {
     # Check to see if driver reports missing mesh point support
     if  [ -z "$(iw phy phy$1 info | grep 'mesh point')" ]; then
         result='' # Indicate interface is not meshable
-    # XRADIO driver reports Mesh Point support incorrectly (there is no support for it)
-    elif [ "$(basename $(readlink /sys/class/net/$interface/device/driver))" == 'xradio_wlan' ]; then	    
+    # XRADIO driver reports Mesh Point but does not actually work
+    elif [ "$(basename $(readlink /sys/class/net/$interface/device/driver))" == 'xradio_wlan' ]; then
         result='' # Indicate interface is actually not meshable
     else
-        result='1' # Indicate interface is  meshable
+        result='1' # Indicate interface is meshable
     fi
 
     echo $result
 }
-
 
 set -e
 
 # Set wireless regulatory domain
 sudo iw reg set CA
 
-# Select physical device that supports 802.11s Mesh Point
-if ! [ -z $(isMeshable 0) ]; then
-    mesh_phy=phy0
-    mesh_dev=$(iw dev | grep phy#0 -A 1 | grep Interface | awk '{print $2}')
-elif ! [ -z $(isMeshable 1) ]; then
-    mesh_phy=phy1
-    mesh_dev=$(iw dev | grep phy#1 -A 1 | grep Interface | awk '{print $2}')
-else
+# Find first meshpoint device you can
+for int in $(find /sys/class/net/* -maxdepth 1 -print0 | xargs -0 -l basename); do
+    if [ -d "/sys/class/net/$int/wireless" ]; then
+        phy=$(iw dev "$int" info | grep wiphy | awk '{print $2}')
+        if [ ! -z "$phy" ]; then
+            if ! [ -z $(isMeshable "$phy") ]; then
+                mesh_dev="$int"
+            fi
+        fi
+    fi
+done
+
+# If no device found exit with error
+if [ -z "$mesh_dev" ]; then
     exit 1
 fi
 

--- a/scripts/mesh-point/mesh-point
+++ b/scripts/mesh-point/mesh-point
@@ -21,7 +21,7 @@ set -e
 # Set wireless regulatory domain
 sudo iw reg set CA
 
-# Find first 802.11s Mesh Point capable device you can
+# Find first 802.11s Mesh Point capable device
 for int in $(find /sys/class/net/* -maxdepth 1 -print0 | xargs -0 -l basename); do
     if [ -d "/sys/class/net/$int/wireless" ]; then
         phy=$(iw dev "$int" info | grep wiphy | awk '{print $2}')

--- a/scripts/mesh-point/mesh-point
+++ b/scripts/mesh-point/mesh-point
@@ -21,7 +21,7 @@ set -e
 # Set wireless regulatory domain
 sudo iw reg set CA
 
-# Find first meshpoint device you can
+# Find first 802.11s Mesh Point capable device you can
 for int in $(find /sys/class/net/* -maxdepth 1 -print0 | xargs -0 -l basename); do
     if [ -d "/sys/class/net/$int/wireless" ]; then
         phy=$(iw dev "$int" info | grep wiphy | awk '{print $2}')


### PR DESCRIPTION
Old mesh point scanned only phy0 and phy1, 

Update scans all interfaces, checks if they are wireless, determines the phy id, then checks for meshpoint. This way any phyx can be mesh point not just 0 and 1