### PR TITLE
[Contrib] Captive Portal like lock for internet bound connection on an offline node

### DIFF
--- a/contrib/offline/install.sh
+++ b/contrib/offline/install.sh
@@ -5,7 +5,7 @@ echo iptables -t nat -I PREROUTING -i wlan-ap -p tcp --dport 80 -j DNAT --to-des
 
 # Prevent masquarading out ipv4
 # This is prevent IPTUNNEL and routing to the internet (Exit node)
-sed -i "/iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE/d" /etc/hostapd/nat.sh 
+sudo sed -i "/iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE/d" /etc/hostapd/nat.sh 
 
 # Set nginx to redirect any 404 errors to /
-sed "s/}/    error_page 404 =200 \/index.html;\\n}/" /etc/nginx/sites-enabled/main.conf
+sudo sed -i "s/}/    error_page 404 =200 \/index.html;\\n}/" /etc/nginx/sites-enabled/main.conf

--- a/contrib/offline/install.sh
+++ b/contrib/offline/install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Redirect all IPv4 80 traffic to the pi
+echo iptables -t nat -I PREROUTING -i wlan-ap -p tcp --dport 80 -j DNAT --to-destination 10.0.0.1:80 | sudo tee --append  /etc/hostapd/nat.sh > /dev/null 
+
+# Prevent masquarading out ipv4
+# This is prevent IPTUNNEL and routing to the internet (Exit node)
+sed -i "/iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE/d" /etc/hostapd/nat.sh 
+
+# Set nginx to redirect any 404 errors to /
+sed "s/}/    error_page 404 =200 \/index.html;\\n}/" /etc/nginx/sites-enabled/main.conf

--- a/contrib/offline/redirect-port-80.sh
+++ b/contrib/offline/redirect-port-80.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Backup file
+if ! [ -f "/etc/hostapd/nat.sh.org" ]; then
+  sudo cp /etc/hostapd/nat.sh /etc/hostapd/nat.sh.org
+fi
+
 # Redirect all IPv4 80 traffic to the pi
 echo iptables -t nat -I PREROUTING -i wlan-ap -p tcp --dport 80 -j DNAT --to-destination 10.0.0.1:80 | sudo tee --append  /etc/hostapd/nat.sh > /dev/null 
 
@@ -9,3 +14,4 @@ sudo sed -i "/iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE/d" /etc/hosta
 
 # Set nginx to redirect any 404 errors to /
 sudo sed -i "s/}/    error_page 404 =200 \/index.html;\\n}/" /etc/nginx/sites-enabled/main.conf
+sudo systemctl restart hostapd

--- a/contrib/offline/redirect-port-80.sh
+++ b/contrib/offline/redirect-port-80.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 
 # Backup file
-if ! [ -f "/etc/hostapd/nat.sh.org" ]; then
-  sudo cp /etc/hostapd/nat.sh /etc/hostapd/nat.sh.org
+if ! [ -f "/etc/hostapd/nat.sh.bak" ]; then
+  sudo cp /etc/hostapd/nat.sh /etc/hostapd/nat.sh.bak
 fi
 
 # Redirect all IPv4 80 traffic to the pi
 echo iptables -t nat -I PREROUTING -i wlan-ap -p tcp --dport 80 -j DNAT --to-destination 10.0.0.1:80 | sudo tee --append  /etc/hostapd/nat.sh > /dev/null 
 
-# Prevent masquarading out ipv4
-# This is prevent IPTUNNEL and routing to the internet (Exit node)
+# Prevent masquerading out IPv4
+# This is to prevent IPTUNNEL and routing to the internet (Exit node)
 sudo sed -i "/iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE/d" /etc/hostapd/nat.sh 
 
 # Set nginx to redirect any 404 errors to /
-sudo sed -i "s/}/    error_page 404 =200 \/index.html;\\n}/" /etc/nginx/sites-enabled/main.conf
+sed -i '$i    error_page 404 =200 /index.html;' /etc/nginx/sites-enabled/main.conf
 sudo systemctl restart hostapd


### PR DESCRIPTION
Redirects to Pi's webserver when using WIFI Access Point on a node that will not route ipv4 (Internet) traffic.

- Removed IPV4 masquerading
- Addes redirect to 10.0.0.1 for all port 80 bound traffic
- Adds 404 redirect to / for nginx