### PR TITLE
Password Change

### DIFF
--- a/scripts/install2
+++ b/scripts/install2
@@ -133,11 +133,9 @@ else
     # Check for default password is still set for user pi
     # If it is force password before reboot
     # shellcheck disable=SC2016
-    DEFAULT='oAHCmfg/$uJxKZP0oOHCaz5CzamfdyDb12tKfm9RsXP1M2MmzonMyChiudpmw2gEMHEdEefrkvnQ2O4vKdXzMUXexH3bF91'
+   
     # shellcheck disable=SC2143,SC2086
-    if [ "$(sudo grep pi: /etc/shadow | grep $DEFAULT)" ]; then
-        CHANGE_PASSWORD="pi"
-    fi
+    CHANGE_PASSWORD="pi"
 
     if [[ $BOARD_REVISION == *"900092"* || $BOARD_REVISION == *"900093"* || $BOARD_REVISION == *"9000c1"* ]]; then
         BOARD_NAME="Zero"


### PR DESCRIPTION
You may not be able to detect if default password is set

Checking shadowed file doesnt seem to work
 `oAHCmfg/$uJxKZP0oOHCaz5CzamfdyDb12tKfm9RsXP1M2MmzonMyChiudpmw2gEMHEdEefrkvnQ2O4vKdXzMUXexH3bF91`
`D12eVhKX$00kKcOd8ExXk0ZruVWRQnukJi4CEW7Jg7DAgf3E6umxe4PQn7ac4X4TobozWbBIthsUM26EA7ZY4Ypvv63H121`

Can people check there "raspberry" password hash in /etc/shadow see if it matches either of the two above?

Is there any other way to checking for passwords that have not changed?