### PR TITLE
Firewall update - Yggdrasil Client

### DIFF
--- a/scripts/firewall/rules.v4
+++ b/scripts/firewall/rules.v4
@@ -14,7 +14,7 @@
 -A INPUT -p tcp -m tcp --dport 3000 -j ACCEPT
 -A INPUT -p tcp -m tcp --dport 4001 -j ACCEPT
 -A INPUT -p tcp -m tcp --dport 5201 -j ACCEPT
--A INPUT -p tcp -m udp --dport 8008 -j ACCEPT
+-A INPUT -p udp -m udp --dport 8008 -j ACCEPT
 -A INPUT -p tcp -m tcp --dport 9090 -j ACCEPT
 -A INPUT -p tcp -m tcp --dport 9100 -j ACCEPT
 -A INPUT -i wlan+ -j ACCEPT

--- a/scripts/firewall/rules.v6
+++ b/scripts/firewall/rules.v6
@@ -2,6 +2,7 @@
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
+:YGGCLIENT - [0:0]
 -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
@@ -16,5 +17,6 @@
 -A INPUT -j ACCEPT -p udp --dport 12345
 -A INPUT -j ACCEPT -p udp --dport 9001 -d ff02::114
 -A INPUT -j REJECT --reject-with icmp6-port-unreachable
--A FORWARD -i ygg0 -d 300::/8 -j REJECT --reject-with icmp6-port-unreachable
+-A FORWARD -i ygg0 -d 300::/8 -j YGGCLIENT
+-A YGGCLIENT -j REJECT --reject-with icmp6-port-unreachable
 COMMIT

--- a/scripts/firewall/rules.v6
+++ b/scripts/firewall/rules.v6
@@ -16,4 +16,5 @@
 -A INPUT -j ACCEPT -p udp --dport 12345
 -A INPUT -j ACCEPT -p udp --dport 9001 -d ff02::114
 -A INPUT -j REJECT --reject-with icmp6-port-unreachable
+-A FORWARD -i ygg0 -d 300::/8 -j REJECT --reject-with icmp6-port-unreachable
 COMMIT

--- a/scripts/firewall/rules.v6
+++ b/scripts/firewall/rules.v6
@@ -18,5 +18,6 @@
 -A INPUT -j ACCEPT -p udp --dport 9001 -d ff02::114
 -A INPUT -j REJECT --reject-with icmp6-port-unreachable
 -A FORWARD -i ygg0 -d 300::/8 -j YGGCLIENT
--A YGGCLIENT -j REJECT --reject-with icmp6-port-unreachable
+-A FORWARD -i ygg0 -d 300::/8 -j REJECT --reject-with icmp6-port-unreachable
+#-A YGGCLIENT -j ACCEPT -p tcp --dport 22
 COMMIT


### PR DESCRIPTION
Created group `YGGCLIENT` in ipv6 firewall.

Rules in this group are run against any INCOMING from yaggdrasil to a Yaggdrasi -Client ip address before being rejected.

# Open Port

To open up a port for routing you simply have to add rules to this group as ACCEPT as such

```
-A YGGCLIENT -j ACCEPT -p tcp --dport 22
```
# Breakdown

`-A YGGCLIENT` -Adding to the bottom of the YGGCLIENT group
`-j ACCEPT` - Allow traffic to  be routed
`-p tcp` TCP traffic (use -p udp for UDP traffic)
`--dport 22` Destination port. This example uses SSH port 22

So as another example for minetest  it uses UDP port 30000 so

```
-A YGGCLIENT -j ACCEPT -p udp --dport 30000
```

# Allow all traffic 
```
-A YGGCLIENT -j ACCEPT 
```
