### PR TITLE
Update rules.v6 [ygg]

### DIFF
--- a/scripts/firewall/rules.v6
+++ b/scripts/firewall/rules.v6
@@ -31,5 +31,4 @@
 -A YGGDRASIL -j ACCEPT -p tcp --dport 4001
 -A YGGDRASIL -j ACCEPT -p tcp --dport 9090
 -A YGGDRASIL -j ACCEPT -p tcp --dport 9100
-#-A YGGCLIENT -j ACCEPT -p tcp --dport 22
 COMMIT

--- a/scripts/firewall/rules.v6
+++ b/scripts/firewall/rules.v6
@@ -8,7 +8,7 @@
 -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
--A INPUT -j ACCEPT -p udp --dport 12345
+-A INPUT -j ACCEPT -p tcp --dport 12345
 -A INPUT -j ACCEPT -p udp --dport 9001 -d ff02::114
 -A INPUT -i tun0 -d fc00::/8 -j CJDNS
 -A INPUT -i ygg0 -d 200::/8 -j YGGDRASIL

--- a/scripts/firewall/rules.v6
+++ b/scripts/firewall/rules.v6
@@ -2,21 +2,34 @@
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
+:CJDNS - [0:0]
+:YGGDRASIL - [0:0]
 :YGGCLIENT - [0:0]
 -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -p ipv6-icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
--A INPUT -j ACCEPT -p tcp --dport 22
--A INPUT -j ACCEPT -p tcp --dport 80
--A INPUT -j ACCEPT -p tcp --dport 443
--A INPUT -j ACCEPT -p tcp --dport 3000
--A INPUT -j ACCEPT -p tcp --dport 5201
--A INPUT -j ACCEPT -p tcp --dport 4001
--A INPUT -j ACCEPT -p tcp --dport 9090
--A INPUT -j ACCEPT -p tcp --dport 9100
 -A INPUT -j ACCEPT -p udp --dport 12345
 -A INPUT -j ACCEPT -p udp --dport 9001 -d ff02::114
+-A INPUT -i tun0 -d fc00::/8 -j CJDNS
+-A INPUT -i ygg0 -d 200::/8 -j YGGDRASIL
 -A INPUT -j REJECT --reject-with icmp6-port-unreachable
 -A FORWARD -i ygg0 -d 300::/8 -j YGGCLIENT
 -A FORWARD -i ygg0 -d 300::/8 -j REJECT --reject-with icmp6-port-unreachable
+-A CJDNS -j ACCEPT -p tcp --dport 22
+-A CJDNS -j ACCEPT -p tcp --dport 80
+-A CJDNS -j ACCEPT -p tcp --dport 443
+-A CJDNS -j ACCEPT -p tcp --dport 3000
+-A CJDNS -j ACCEPT -p tcp --dport 5201
+-A CJDNS -j ACCEPT -p tcp --dport 4001
+-A CJDNS -j ACCEPT -p tcp --dport 9090
+-A CJDNS -j ACCEPT -p tcp --dport 9100
+-A YGGDRASIL -j ACCEPT -p tcp --dport 22
+-A YGGDRASIL -j ACCEPT -p tcp --dport 80
+-A YGGDRASIL -j ACCEPT -p tcp --dport 443
+-A YGGDRASIL -j ACCEPT -p tcp --dport 3000
+-A YGGDRASIL -j ACCEPT -p tcp --dport 5201
+-A YGGDRASIL -j ACCEPT -p tcp --dport 4001
+-A YGGDRASIL -j ACCEPT -p tcp --dport 9090
+-A YGGDRASIL -j ACCEPT -p tcp --dport 9100
+#-A YGGCLIENT -j ACCEPT -p tcp --dport 22
 COMMIT


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29005789/52022432-db20df80-24c6-11e9-95b0-3ed329339bf9.png)
There are 4 ipv6 link types
Standard local link ipv6
incomming traffic from CJDNS to the node (inbound on tun0)
incomming traffic from YGGDRASIL to the node  (inbound on ygg0)
incomming Traffic from Yggdrasil to the Yggdrasil client (forward from ygg0)

do we want

- Separate table/chain for each one
- Common ports across YGG and CJDNS, ability to add unique ones to each one
 or what?


Current PR separate table for CJDNS and YGG, none for local link ( cause it will probably by ipv4 anyway)