### PR TITLE
20hmz band

### DIFF
--- a/scripts/mesh-adhoc/mesh-adhoc
+++ b/scripts/mesh-adhoc/mesh-adhoc
@@ -20,9 +20,9 @@ sudo ifconfig $mesh_dev up
 # Optionally assign IPv4 address to the mesh_dev interface
 # sudo ifconfig $mesh_dev 192.168.X.Y
 
-# Join the mesh network with radio in HT40+ htmode to enable 802.11n rates
-##TODO## Check for HT40+ first
-sudo iw dev $mesh_dev ibss join MESH_NAME 2412 HT40+
+# Join the mesh network with.
+# To join radio in HT40+ htmode (enable 802.11n rates) add  HT40+ to end of this line
+sudo iw dev $mesh_dev ibss join MESH_NAME 2412
 
 # Restart cjdns
 sudo killall cjdroute

--- a/scripts/mesh-adhoc/mesh-adhoc
+++ b/scripts/mesh-adhoc/mesh-adhoc
@@ -20,7 +20,7 @@ sudo ifconfig $mesh_dev up
 # Optionally assign IPv4 address to the mesh_dev interface
 # sudo ifconfig $mesh_dev 192.168.X.Y
 
-# Join the mesh network with.
+# Join the mesh network
 # To join radio in HT40+ htmode (enable 802.11n rates) add  HT40+ to end of this line
 sudo iw dev $mesh_dev ibss join MESH_NAME 2412
 

--- a/scripts/mesh-point/mesh-point
+++ b/scripts/mesh-point/mesh-point
@@ -50,8 +50,9 @@ sudo ifconfig $mesh_dev up
 # Optionally assign IPv4 address to the mesh_dev interface
 # sudo ifconfig $mesh_dev 192.168.X.Y
 
-# Join the mesh network with radio in HT40+ htmode to enable 802.11n rates
-sudo iw dev $mesh_dev mesh join MESH_NAME freq 2412 HT40+
+# Join the mesh network
+# To join radio in HT40+ htmode (enable 802.11n rates) add  HT40+ to end of this line
+sudo iw dev $mesh_dev mesh join MESH_NAME freq 2412
 
 # Disable forwarding since we rely on cjdns to do routing and only uses Mesh Point as a point-to-point link
 sudo iw dev $mesh_dev set mesh_param mesh_fwding=0


### PR DESCRIPTION
Issue #263

Discussion welcome


----
CP from #217 
-----

## TL;DR Summary

### 20MHz 
- Less Noise = More stable
- Less throughput
- More supported devices

### 40Mhz
- More throughput available
- More noise - Possibly weaker link

### Issues
- If we switch mesh point old versions will not mesh with new versions.

# Longer description

2.4 GHz Wifi is made up of 11 channels spaced 5Mhz apart ~(total spectrum 50 MHz)

Because we use define channels by "Center frequencies" (that is the frequency that is in the middle of the band) There is another ~10MHz on each end of the spectrum. (As an example Channel 1 is known as 2412Mhz, because that's the middle.  It actually starts at 2401Mhz. ) That brings the total spectrum up to ~ 65 MHz.

Standard WIFI channel is 20MHz, this means it covers about 4-5 channels. (basically 2 channels in each direction of the selected channel)  Any overlapping channels make NOISE for the channels they overlap.
![image](https://user-images.githubusercontent.com/29005789/49342933-3baeb000-f62f-11e8-83cc-eecc3b238da7.png)

In a "Best case" scenario you dont want channels to be overlapping. This is why there they say to run wifi only on 1 6 11 because then they dont overlap. If they overlap then its just noise. This means there are only 3 non-overlapping usable channels on 2.4 Ghz. (65 Mhz /20Mhz=~3 + a bit of space for separating channels to prevent noise.)

40MHz is a little more difficult.  First you can only fit ONE 40mhz channel in 2.4 Ghz without overlapping.
![image](https://user-images.githubusercontent.com/29005789/49342965-ad86f980-f62f-11e8-9a91-086f3bb44790.png)

## Current model
Current model we use 1 x 20MHz channel for Access point (channel 1) and 1 x 40Mhz channel for Mesh Point (and as such AdHoc etc)

- This takes over the whole spectrum.  
- Any other devices on channels 2, 3 running 20MHz create nose for the access point
- Any other devices on channels 1,2,3,4,5,6,7,8,9 running 40Mhz create nose for the access point
- Any devices running on channels 2,3,4,5,6,7,8,9,10,11 running 20MHz create noise for the mesh
- Any devices running on channels 2,3,4,5,6,7,8,9,10 running 40Mhz create noise for the mesh.

/_\ if there is allot of devices on any other channels/bands that we use we get allot more noise.





