### PR TITLE
Local Links for Yggdrasil during meshing

### DIFF
--- a/scripts/mesh-adhoc/mesh-adhoc
+++ b/scripts/mesh-adhoc/mesh-adhoc
@@ -33,8 +33,8 @@ sudo iw dev $mesh_dev ibss join MESH_NAME 2412
 # Make a local-link ip out of yggdrasil ip if $mesh_dev does not have a local-link ip
 if [ ! -z "$(which yggdrasilctl)" ]; then
   if [ -z "$(ip addr show dev $mesh_dev | grep inet6\ fe)" ]; then
-	  ip=$(yggdrasilctl  getSelf | grep "IPv6 address" | awk '{print $3}')
-	  ip address add dev $mesh_dev scope link fe80::${ip:20}/64
+	  ip="$(sudo yggdrasilctl getSelf | grep "IPv6 address" | awk '{print $3}' | cut -d ":" -f5-8)"
+	  ip address add dev $mesh_dev scope link fe80::${ip}/64
   fi
 fi
 

--- a/scripts/mesh-adhoc/mesh-adhoc
+++ b/scripts/mesh-adhoc/mesh-adhoc
@@ -30,5 +30,13 @@ sudo ifconfig $mesh_dev up
 # To join radio in HT40+ htmode (enable 802.11n rates) add HT40+ to end of this line
 sudo iw dev $mesh_dev ibss join MESH_NAME 2412
 
+# Make a local-link ip out of yggdrasil ip if $mesh_dev does not have a local-link ip
+if [ ! -z "$(which yggdrasilctl)" ]; then
+  if [ -z "$(ip addr show dev $mesh_dev | grep inet6\ fe)" ]; then
+	  ip=$(yggdrasilctl  getSelf | grep "IPv6 address" | awk '{print $3}')
+	  ip address add dev $mesh_dev scope link fe80::${ip:20}/64
+  fi
+fi
+
 # Restart cjdns
 sudo killall cjdroute

--- a/scripts/mesh-point/mesh-point
+++ b/scripts/mesh-point/mesh-point
@@ -61,5 +61,13 @@ sudo iw dev $mesh_dev set mesh_param mesh_fwding=0
 # Prevent trying to establish connections with nodes under -65 dBm
 sudo iw dev $mesh_dev set mesh_param mesh_rssi_threshold -65
 
+# Make a local-link ip out of yggdrasil ip if $mesh_dev does not have a local-link ip
+if [ ! -z "$(which yggdrasilctl)" ]; then
+  if [ -z "$(ip addr show dev $mesh_dev | grep inet6\ fe)" ]; then
+	  ip=$(yggdrasilctl  getSelf | grep "IPv6 address" | awk '{print $3}')
+	  ip address add dev $mesh_dev scope link fe80::${ip:20}/64
+  fi
+fi
+
 # Restart cjdns
 sudo killall cjdroute

--- a/scripts/mesh-point/mesh-point
+++ b/scripts/mesh-point/mesh-point
@@ -64,8 +64,8 @@ sudo iw dev $mesh_dev set mesh_param mesh_rssi_threshold -65
 # Make a local-link ip out of yggdrasil ip if $mesh_dev does not have a local-link ip
 if [ ! -z "$(which yggdrasilctl)" ]; then
   if [ -z "$(ip addr show dev $mesh_dev | grep inet6\ fe)" ]; then
-	  ip=$(yggdrasilctl  getSelf | grep "IPv6 address" | awk '{print $3}')
-	  ip address add dev $mesh_dev scope link fe80::${ip:20}/64
+	  ip="$(sudo yggdrasilctl getSelf | grep "IPv6 address" | awk '{print $3}' | cut -d ":" -f5-8)"
+	  ip address add dev $mesh_dev scope link fe80::${ip}/64
   fi
 fi
 


### PR DESCRIPTION
OS SHOULD  assign a local link address to all interface

I came across a scenario where Yggdrasil would not peers, turned out wlan0 interface didn't have an local link address.

This checks patch at the end of mesh-point and mesh-adhoc checks to see if you have Yggdrasil install and are missing a local link address, if you are missing it, it will add one by using yggdrasil's ip address as a template.

it SHOULDN'T happen but if it does i'd rather have an insurance policy that "fixes" it otherwise you dont have a peer.