### PR TITLE
Hostapd fix issue #331

### DIFF
--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -133,6 +133,9 @@ if [ -f /etc/default/hostapd ]; then
     sudo echo DAEMON_CONF="/etc/hostapd.conf" | sudo tee --append /etc/default/hostapd > /dev/null
 fi
 
+# remove existing file that may be masking the service
+sudo rm -rf /etc/systemd/system/hostapd.service
+
 sudo cp "$BASE_DIR/hostapd.service" /etc/systemd/system/hostapd.service
 sudo systemctl daemon-reload
 sudo systemctl enable hostapd.service


### PR DESCRIPTION
After release of v4 (or maybe just before it) RADVD package started creating a `/dev/null` linke to `hostapd.service` designed to mask the service. This broke the install.

This patch removes the mask during install.