### PR TITLE
IPv4 over IPv6 Resolution

### DIFF
--- a/contrib/ipv4-use-first/ipv4-first
+++ b/contrib/ipv4-use-first/ipv4-first
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+
+# gai stands for getaddrinfo, the standard system call for resolving host names
+# Change will use ipv4 over ipv6 when possible
+
+sudo sed -i "s/#precedence ::ffff:0:0/96  100/precedence ::ffff:0:0/96  100/" /etc/gai.conf

--- a/docs/CONTRIB.md
+++ b/docs/CONTRIB.md
@@ -1,0 +1,9 @@
+# ipv4-use-first
+
+Sometimes the system will think that oyu have ipv6 when yggdrasill / cjdns are active. This casues some sites that have both an A and AAAA record not to load  (because it tries the AAAA record).
+
+This script changes gia.conf to lower ipv6 address preferences below ipv4 making ipv4 preferred. gai stands for getaddrinfo, the standard system call for resolving host names.
+
+**USAGE**
+
+`ipv4-first`


### PR DESCRIPTION
Sometimes the system will think that oyu have ipv6 when yggdrasill / cjdns are active. This casues some sites that have both an A and AAAA record not to load  (because it tries the AAAA record)

This script changes gia.conf to lower ipv6 address preferences below ipv4 making ipv4 preferred

gai stands for getaddrinfo, the standard system call for resolving host names