### PR TITLE
Netcat fix

### DIFF
--- a/scripts/install2
+++ b/scripts/install2
@@ -84,7 +84,7 @@ echo "auto lo" | sudo tee /etc/network/interfaces.d/lo > /dev/null
 echo "iface lo inet loopback" | sudo tee --append /etc/network/interfaces.d/lo >> /dev/null
 
 # Replace netcat with IPv6 supported one, see https://unix.stackexchange.com/questions/457670/netcat-how-to-listen-on-a-tcp-port-using-ipv6-address
-sudo apt-get remove -y netcat-traditional netcat6 ncat netcat
+sudo apt-get remove -y netcat-traditional netcat6 ncat netcat || true
 sudo apt-get install -y netcat-openbsd
 
 # Detect missing /sbin from $PATH variable on Debian distros, and add it

--- a/scripts/install2
+++ b/scripts/install2
@@ -84,8 +84,17 @@ echo "auto lo" | sudo tee /etc/network/interfaces.d/lo > /dev/null
 echo "iface lo inet loopback" | sudo tee --append /etc/network/interfaces.d/lo >> /dev/null
 
 # Replace netcat with IPv6 supported one, see https://unix.stackexchange.com/questions/457670/netcat-how-to-listen-on-a-tcp-port-using-ipv6-address
-sudo apt-get remove -y netcat-traditional netcat6 ncat netcat || true
-sudo apt-get install -y netcat-openbsd
+read -p "Replace any IPv4-only netcat software with one that also supports IPv6 (Y/n)?" -n 1 -r
+echo ""
+if [[ $REPLY =~ ^[Nn]$ ]]; then
+    echo -e "The current software will not be removed."
+else
+    sudo apt-get remove -y netcat-traditional || true
+    sudo apt-get remove -y netcat6 || true
+    sudo apt-get remove -y ncat || true
+    sudo apt-get remove -y netcat || true
+    sudo apt-get install -y netcat-openbsd
+fi
 
 # Detect missing /sbin from $PATH variable on Debian distros, and add it
 if ! echo "$PATH" | grep -q "/sbin" ; then

--- a/scripts/install2
+++ b/scripts/install2
@@ -83,6 +83,10 @@ echo iface eth0 inet dhcp | sudo tee --append /etc/network/interfaces.d/eth0 >> 
 echo "auto lo" | sudo tee /etc/network/interfaces.d/lo > /dev/null
 echo "iface lo inet loopback" | sudo tee --append /etc/network/interfaces.d/lo >> /dev/null
 
+# Replace netcat with IPv6 supported one, see https://unix.stackexchange.com/questions/457670/netcat-how-to-listen-on-a-tcp-port-using-ipv6-address
+sudo apt-get remove -y netcat-traditional netcat6 ncat netcat
+sudo apt-get install -y netcat-openbsd
+
 # Detect missing /sbin from $PATH variable on Debian distros, and add it
 if ! echo "$PATH" | grep -q "/sbin" ; then
     # Current environment


### PR DESCRIPTION
@dasanchez and I had an issue with netcat working one meeting, I did some research today, and figured it was [this](https://unix.stackexchange.com/questions/457670/netcat-how-to-listen-on-a-tcp-port-using-ipv6-address). This PR removes potential different versions of netcat, and installs the reccomended one that supports IPv6, `netcat-openbsd`. I have confirmed this is in the Raspbian and Debian repositories.