### PR TITLE
Update mesh-point

### DIFF
--- a/scripts/mesh-point/mesh-point
+++ b/scripts/mesh-point/mesh-point
@@ -21,6 +21,13 @@ set -e
 # Set wireless regulatory domain
 sudo iw reg set CA
 
+# Kill wpa_supplicant if running while no AP active
+# Mesh point interface sometimes will not enter RUNNING status if it is running
+if [ ! -d /sys/class/net/wlan-ap ]; then
+  # Kill wpa_supplicant will sometimes conflicts with Mesh Point
+  sudo killall wpa_supplicant || true
+fi
+
 # Find first 802.11s Mesh Point capable device
 for wlanfile in /sys/class/net/*; do
     int="$(basename "$wlanfile")"


### PR DESCRIPTION
Mesh point interfaces sometimes do not enter "RUNNING" mode. This prevents some services like Yggdrasil to peer.

```
wlan1: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
```

Seems that wpa_supplicant is interfering with this working on some os/wifi device combinations.

Patch will kill wpa_supplicant if running and not access point defined, but better solution required.

Does not to be a good one at the moment - Refrence
https://serverfault.com/questions/869857/systemd-how-to-selectively-disable-wpa-supplicant-for-a-specific-wlan-interface/880575