### PR TITLE
Patch wpa_supplicant for Raspbian

### DIFF
--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -154,5 +154,5 @@ fi
 
 # Apply wpa_supplicant patch 
 # shellcheck disable=SC2024
-sudo patch -F99 -p2 -N -d / < wpa-patch.diff
+sudo patch -F99 -p2 -N  -d / < wpa-patch.diff
 echo "wlan-ap" | sudo tee /etc/wpa_devices

--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -154,5 +154,5 @@ fi
 
 # Apply wpa_supplicant patch 
 # shellcheck disable=SC2024
-sudo patch -p2 -N -d / < wpa-patch.diff
+sudo patch -F99 -p2 -N -d / < wpa-patch.diff
 echo "wlan-ap" | sudo tee /etc/wpa_devices

--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -153,5 +153,6 @@ if ! grep -q rfkill /etc/rc.local; then
 fi
 
 # Apply wpa_supplicant patch 
+# shellcheck disable=SC2024
 sudo patch -p2 -N -d / < wpa-patch.diff
 echo "wlan-ap" | sudo tee /etc/wpa_devices

--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -154,5 +154,7 @@ fi
 
 # Apply wpa_supplicant patch 
 # shellcheck disable=SC2024
-sudo patch -F99 -p2 -N  -d / < wpa-patch.diff
-echo "wlan-ap" | sudo tee /etc/wpa_devices
+if [ -f /lib/dhcpcd/dhcpcd-hooks/10-wpa_supplicant ]; then
+    sudo patch -F99 -p2 -N  -d / < "$BASE_DIR/wpa-patch.diff"
+    echo "wlan-ap" | sudo tee /etc/wpa_devices
+fi

--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -151,3 +151,7 @@ fi
 if ! grep -q rfkill /etc/rc.local; then
     sudo sed -i 's/^exit 0/rfkill unblock wifi \&\& service hostapd restart\nexit 0/' /etc/rc.local 
 fi
+
+# Apply wpa_supplicant patch 
+sudo patch -p2 -N -d / < wpa-patch.diff
+echo "wlan-ap" | sudo tee /etc/wpa_devices

--- a/scripts/hostapd/wpa-patch.diff
+++ b/scripts/hostapd/wpa-patch.diff
@@ -10,7 +10,7 @@
         dir=$(key_get_value "[[:space:]]*ctrl_interface=" \
                 "$wpa_supplicant_conf")
         dir=$(trim "$dir")
-@@ -36,6 +39,9 @@
+@@ -35,6 +38,9 @@
 
  wpa_supplicant_start()
  {
@@ -20,7 +20,7 @@
         # If the carrier is up, don't bother checking anything
         [ "$ifcarrier" = "up" ] && return 0
 
-@@ -70,6 +76,9 @@
+@@ -69,6 +75,9 @@
 
  wpa_supplicant_reconfigure()
  {
@@ -30,7 +30,7 @@
         dir=$(wpa_supplicant_ctrldir)
         [ -z "$dir" ] && return 1
         if ! wpa_cli -p "$dir" -i "$interface" status >/dev/null 2>&1; then
-@@ -88,6 +97,9 @@
+@@ -87,6 +96,9 @@
 
  wpa_supplicant_stop()
  {
@@ -40,13 +40,11 @@
         dir=$(wpa_supplicant_ctrldir)
         [ -z "$dir" ] && return 1
         wpa_cli -p "$dir" -i "$interface" status >/dev/null 2>&1 || return 0
-@@ -103,7 +115,8 @@
-
+@@ -103,6 +115,7 @@
  if [ "$ifwireless" = "1" ] && \
      type wpa_supplicant >/dev/null 2>&1 && \
--    type wpa_cli >/dev/null 2>&1
-+    type wpa_cli >/dev/null 2>&1 &&
-+    ([ -f /etc/wpa_devices ] && grep -q  "$interface" /etc/wpa_devices)
+     type wpa_cli >/dev/null 2>&1
++    ([ -f /etc/wpa_devices ] && grep -q  "$interface" /etc/wpa_devices); then
  then
-
         case "$reason" in
+        PREINIT)        wpa_supplicant_start;;

--- a/scripts/hostapd/wpa-patch.diff
+++ b/scripts/hostapd/wpa-patch.diff
@@ -40,10 +40,12 @@
         dir=$(wpa_supplicant_ctrldir)
         [ -z "$dir" ] && return 1
         wpa_cli -p "$dir" -i "$interface" status >/dev/null 2>&1 || return 0
-@@ -103,6 +115,7 @@
+@@ -102,7 +114,8 @@
+
  if [ "$ifwireless" = "1" ] && \
      type wpa_supplicant >/dev/null 2>&1 && \
-     type wpa_cli >/dev/null 2>&1
+-    type wpa_cli >/dev/null 2>&1
++    type wpa_cli >/dev/null 2>&1 && \
 +    ([ -f /etc/wpa_devices ] && grep -q  "$interface" /etc/wpa_devices); then
  then
         case "$reason" in

--- a/scripts/hostapd/wpa-patch.diff
+++ b/scripts/hostapd/wpa-patch.diff
@@ -1,12 +1,52 @@
 +++ /a/lib/dhcpcd/dhcpcd-hooks/10-wpa_supplicant      2019-07-19 21:31:41.130053542 +0100
 +++ /b/lib/dhcpcd/dhcpcd-hooks/10-wpa_supplicant      2019-07-19 21:58:03.470829257 +0100
-@@ -102,7 +102,8 @@
+@@ -20,6 +20,9 @@
+
+ wpa_supplicant_ctrldir()
+ {
++        if ([ -f /etc/wpa_devices ] && ! grep -q  "$interface" /etc/wpa_devices); then
++            exit 0
++        fi
+        dir=$(key_get_value "[[:space:]]*ctrl_interface=" \
+                "$wpa_supplicant_conf")
+        dir=$(trim "$dir")
+@@ -36,6 +39,9 @@
+
+ wpa_supplicant_start()
+ {
++        if ([ -f /etc/wpa_devices ] && ! grep -q  "$interface" /etc/wpa_devices); then
++            exit 0
++        fi
+        # If the carrier is up, don't bother checking anything
+        [ "$ifcarrier" = "up" ] && return 0
+
+@@ -70,6 +76,9 @@
+
+ wpa_supplicant_reconfigure()
+ {
++        if ([ -f /etc/wpa_devices ] && ! grep -q  "$interface" /etc/wpa_devices); then
++            exit 0
++        fi
+        dir=$(wpa_supplicant_ctrldir)
+        [ -z "$dir" ] && return 1
+        if ! wpa_cli -p "$dir" -i "$interface" status >/dev/null 2>&1; then
+@@ -88,6 +97,9 @@
+
+ wpa_supplicant_stop()
+ {
++        if ([ -f /etc/wpa_devices ] && ! grep -q  "$interface" /etc/wpa_devices); then
++            exit 0
++        fi
+        dir=$(wpa_supplicant_ctrldir)
+        [ -z "$dir" ] && return 1
+        wpa_cli -p "$dir" -i "$interface" status >/dev/null 2>&1 || return 0
+@@ -103,7 +115,8 @@
 
  if [ "$ifwireless" = "1" ] && \
      type wpa_supplicant >/dev/null 2>&1 && \
 -    type wpa_cli >/dev/null 2>&1
 +    type wpa_cli >/dev/null 2>&1 &&
-+    ([ -f /etc/wpa_devices ] && ! [ grep -q  "$ifwireless" /etc/wpa_devices >/dev/null 2>&1 ])
++    ([ -f /etc/wpa_devices ] && grep -q  "$interface" /etc/wpa_devices)
  then
+
         case "$reason" in
-        PREINIT)        wpa_supplicant_start;;

--- a/scripts/hostapd/wpa-patch.diff
+++ b/scripts/hostapd/wpa-patch.diff
@@ -1,5 +1,5 @@
---- /tmp/10-wpa_supplicant      2019-07-19 21:31:41.130053542 +0100
-+++ /lib/dhcpcd/dhcpcd-hooks/10-wpa_supplicant  2019-07-19 21:58:03.470829257 +0100
++++ /a/lib/dhcpcd/dhcpcd-hooks/10-wpa_supplicant      2019-07-19 21:31:41.130053542 +0100
++++ /b/lib/dhcpcd/dhcpcd-hooks/10-wpa_supplicant      2019-07-19 21:58:03.470829257 +0100
 @@ -102,7 +102,8 @@
 
  if [ "$ifwireless" = "1" ] && \

--- a/scripts/hostapd/wpa-patch.diff
+++ b/scripts/hostapd/wpa-patch.diff
@@ -1,0 +1,12 @@
+--- /tmp/10-wpa_supplicant      2019-07-19 21:31:41.130053542 +0100
++++ /lib/dhcpcd/dhcpcd-hooks/10-wpa_supplicant  2019-07-19 21:58:03.470829257 +0100
+@@ -102,7 +102,8 @@
+
+ if [ "$ifwireless" = "1" ] && \
+     type wpa_supplicant >/dev/null 2>&1 && \
+-    type wpa_cli >/dev/null 2>&1
++    type wpa_cli >/dev/null 2>&1 &&
++    ([ -f /etc/wpa_devices ] && ! [ grep -q  "$ifwireless" /etc/wpa_devices >/dev/null 2>&1 ])
+ then
+        case "$reason" in
+        PREINIT)        wpa_supplicant_start;;


### PR DESCRIPTION
Fixes #403 

Patch reads a file `/etc/wpa_devices` for list of interfaces and ignores any interfaces that are not on the list.