### PR TITLE
socat SSB proxy

### DIFF
--- a/scripts/ssb/install
+++ b/scripts/ssb/install
@@ -6,7 +6,7 @@ set -e
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Install dependencies
-sudo apt-get install -y socat python-dev libtool python-setuptools autoconf automake
+sudo apt-get install -y socat python-dev libtool python-setuptools autoconf automake socat
 
 # Install node.js shared module
 # shellcheck source=../shared/node.js/install
@@ -31,6 +31,8 @@ sudo systemctl start ssb.service
 sudo cp "$BASE_DIR/ssb-broadcast-service.sh" "/usr/local/bin/ssb-broadcast-service.sh"
 sudo cp "$BASE_DIR/ssb-broadcast.service" /etc/systemd/system/ssb-broadcast.service
 sudo sed -i "s|__USER__|${currentUser}|g" /etc/systemd/system/ssb-broadcast.service
+sudo cp "$BASE_DIR/ssb-ipv6-broadcast.service" "/etc/systemd/system/ssb-ipv6-broadcast.service"
 
 sudo systemctl daemon-reload
 sudo systemctl enable ssb-broadcast.service
+sudo systemctl enable ssb-ipv6-broadcast.service

--- a/scripts/ssb/ssb-ipv6-broadcast.service
+++ b/scripts/ssb/ssb-ipv6-broadcast.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Scuttlebot (SSB) Service IPv6 Broadcast
+Wants=network.target
+After=ssb.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/socat UDP6-LISTEN:8008,fork,su=nobody UDP4:127.0.0.1:8008
+ExecStop=/bin/kill -s QUIT $MAINPID
+Restart=on-failure
+RestartSec=10s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
added SOCAT to proxy broadcast packest aimed at ipv6 (cjdns/yggdarsil) packets to ssb's ipv4 port

Ref #350