### PR TITLE
Allow non-onboard wifi as AP

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -37,7 +37,7 @@ A short summary of each module is directly below. Documentation for specific abi
 | :------------------------------ | :--------------------------------------------- | :---------- |
 | `WITH_MESH_POINT`               | None                                           | Set to `true` if you have a suitable USB WiFi adapter and want to configure it as a 802.11s Mesh Point interface. |
 | `WITH_AD_HOC`                   | None                                           | Set to `true` if you have a suitable USB WiFi adapter and want to configure it as a IBSS Ad-hoc interface. |
-| `WITH_WIFI_AP`                  | None                                           | Set to `true` if you have a suitable Onboard WIfI adapter or USB WiFi adapter and want to use it as an Access Point. The default configuration routes all traffic to the Ethernet port `eth0`. |
+| `WITH_WIFI_AP`                  | None                                           | Set to `true` if you have a suitable Onboard WiFi adapter or USB WiFi adapter and want to use it as an Access Point. The default configuration routes all traffic to the Ethernet port `eth0`. |
 | `WITH_FIREWALL`                 | None                                           | Set to `true` if you want to enable a basic firewall on your node.|
 | `WITH_CJDNS_IPTUNNEL`           | None                                           | Set to `true` if you want to use the cjdns iptunnel feature to set up an Internet gateway for your node. To configure as a server (exit Internet traffic for other nodes), create **/etc/cjdns.iptunnel.server** containing a newline-separated list of cjdns public keys of allowed clients. To configure as a client (use an exit server to access the Internet), create **/etc/cjdns.iptunnel.client** containing a newline-separated list of cjdns public keys of the gateway servers. You can only configure as one or the other, not both. |
 | `WITH_IPFS`                     | **80**: HTTP-to-IPFS gateway at `/ipfs/HASH`   | Set to `true` if you want to install [IPFS](https://ipfs.io). |
@@ -83,7 +83,7 @@ Value: `interface on system`
 Default: `The first interface that has a name other than wlan-ap`
 
 ## Hostapd - WITH_WIFI_AP
-Configure hostapd to create an access point over one of the WiFi adapters available. 
+Configure hostapd to create an access point over one of the WiFi adapters available. The selected device will be pinned as `wlan-ap` to prevent run conditions.
 
 During installation you will be asked to select additional settings.
 
@@ -91,11 +91,11 @@ During installation you will be asked to select additional settings.
 
 **WPA-PSK**
 
-Traditional wireless password only encryption. You will be asked for a password as well
+Traditional wireless password only encryption. You will be asked for a password as well.
 
 **WPA-EAP** 
 
-Generates certificates and provides a Login/Password means of authentication. Note you may need to set the invalid CA.
+Generates certificates and provides a Login/Password means of authentication. Note you may need to set the invalid CA. You will be asked for a password. The username will be guest. Additional accounts can be made by editing `/etc/hostapd/hostapd.eap_user`.
 
 ### WiFi adapter 
 
@@ -103,7 +103,7 @@ Generates certificates and provides a Login/Password means of authentication. No
 
 Uses the onboard adapter if available for an Access Point
 
-**Extneral Adapter**
+**External Adapter**
 
 Select one of the adapters available on your device to be the Access Point. You can have the system recognize it by Mac address or Driver. 
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -37,7 +37,7 @@ A short summary of each module is directly below. Documentation for specific abi
 | :------------------------------ | :--------------------------------------------- | :---------- |
 | `WITH_MESH_POINT`               | None                                           | Set to `true` if you have a suitable USB WiFi adapter and want to configure it as a 802.11s Mesh Point interface. |
 | `WITH_AD_HOC`                   | None                                           | Set to `true` if you have a suitable USB WiFi adapter and want to configure it as a IBSS Ad-hoc interface. |
-| `WITH_WIFI_AP`                  | None                                           | Set to `true` if you have a Raspberry Pi 3 and want to configure the on-board WiFi as an Access Point. The default configuration routes all traffic to the Ethernet port `eth0`. |
+| `WITH_WIFI_AP`                  | None                                           | Set to `true` if you have a suitable Onboard WIfI adapter or USB WiFi adapter and want to use it as an Access Point. The default configuration routes all traffic to the Ethernet port `eth0`. |
 | `WITH_FIREWALL`                 | None                                           | Set to `true` if you want to enable a basic firewall on your node.|
 | `WITH_CJDNS_IPTUNNEL`           | None                                           | Set to `true` if you want to use the cjdns iptunnel feature to set up an Internet gateway for your node. To configure as a server (exit Internet traffic for other nodes), create **/etc/cjdns.iptunnel.server** containing a newline-separated list of cjdns public keys of allowed clients. To configure as a client (use an exit server to access the Internet), create **/etc/cjdns.iptunnel.client** containing a newline-separated list of cjdns public keys of the gateway servers. You can only configure as one or the other, not both. |
 | `WITH_IPFS`                     | **80**: HTTP-to-IPFS gateway at `/ipfs/HASH`   | Set to `true` if you want to install [IPFS](https://ipfs.io). |
@@ -81,6 +81,31 @@ Default: `2412`
 Defines the interface AdHoc will run on.
 Value: `interface on system`  
 Default: `The first interface that has a name other than wlan-ap`
+
+## Hostapd - WITH_WIFI_AP
+Configure hostapd to create an access point over one of the WiFi adapters available. 
+
+During installation you will be asked to select additional settings.
+
+### Type of WPA
+
+**WPA-PSK**
+
+Traditional wireless password only encryption. You will be asked for a password as well
+
+**WPA-EAP** 
+
+Generates certificates and provides a Login/Password means of authentication. Note you may need to set the invalid CA.
+
+### WiFi adapter 
+
+**Onboard Adapter**
+
+Uses the onboard adapter if available for an Access Point
+
+**Extneral Adapter**
+
+Select one of the adapters available on your device to be the Access Point. You can have the system recognize it by Mac address or Driver. 
 
 ## CJDNS
 Cjdns (Caleb James DeLisle's Network Suite) is a networking protocol and reference implementation. It is founded on the ideology that networks should be easy to set up, protocols should scale smoothly, and security should be built in by default.

--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -139,7 +139,7 @@ for wlanfile in /sys/class/net/wlan*; do
 #    mac="$(cat /sys/class/net/$wlan/address)"
     if [[ "$driver" == "xradio_wlan" || "$driver" == "brcm80211" || "$driver" == "brcmfmac" || "$driver" == "rtl8189fs" ]]; then
     
-        askModule "WITH_ONBOARD_WIFI" "HostAP - Found an onboard WiFi. Configure it as an Access Point?" "n"
+        askModule "WITH_ONBOARD_WIFI" "HostAP - Found an onboard WiFi. Configure it as an Access Point?" "y"
         if [ "$(checkModule 'WITH_ONBOARD_WIFI')" ]; then
             echo "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"$driver\", ATTR{dev_id}==\"0x0\", ATTR{type}==\"1\", KERNEL==\"wlan*\", NAME=\"wlan-ap\"" |
                 sudo tee /etc/udev/rules.d/70-persistent-net.rules

--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -152,23 +152,40 @@ if [ ! "$(checkModule 'WITH_ONBOARD_WIFI')" ]; then
     askModule "WITH_EXTERNAL_WIFI" "HostAP - Configure External WiFi adapter as an Access Point?" "n"
 fi
 if [ "$(checkModule 'WITH_EXTERNAL_WIFI')" ]; then
+
+    askSelection "Pin adapter by" "1 Mac\n2 Driver"
+    pinBy=$dialogREPLY
+    pinByName[1]="Mac"
+    pinByName[2]="Driver"
+    pinBy=${pinByName[$pinBy]}
+
     OPTION=""
     i=0
     for wlanfile in /sys/class/net/wlan*; do
         wlan="$(basename "$wlanfile")"        
         mac="$(cat /sys/class/net/$wlan/address)"
+        driver="$(basename $(readlink /sys/class/net/$wlan/device/driver))"
         i=$((i+1))
+        DRIVER[$i]=$driver
         MAC[$i]=$mac
-        OPTION="${OPTION} \\n $i $mac"
+        OPTION="${OPTION} \\n $i $mac $driver"
     done
-    askSelection "Select Adapter MAC to pin" "$OPTION"
+    askSelection "Select wireless adapter $pinBy to pin" "$OPTION"
+    driver="${DRIVER[$dialogREPLY]}"
     mac="${MAC[$dialogREPLY]}"
+
     if [ -z "$mac" ]; then
         echo "Error unknown response $dialogREPLY"
         exit
     else
-       echo "SUBSYSTEM==\"net\", ACTION==\"add\", ATTR{address}==\"$mac\", ATTR{dev_id}==\"0x0\", ATTR{type}==\"1\", KERNEL==\"wlan*\", NAME=\"wlan-ap\"" |
-          sudo tee /etc/udev/rules.d/70-persistent-net.rules
+       if [[ "$pinBy" == "Mac" ]]; then
+           echo "SUBSYSTEM==\"net\", ACTION==\"add\", ATTR{address}==\"$mac\", ATTR{dev_id}==\"0x0\", ATTR{type}==\"1\", KERNEL==\"wlan*\", NAME=\"wlan-ap\"" |
+              sudo tee /etc/udev/rules.d/70-persistent-net.rules
+       fi
+       if [[ "$pinBy" == "Driver" ]]; then
+           echo "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVER==\"$driver\", ATTR{dev_id}==\"0x0\", ATTR{type}==\"1\", KERNEL==\"wlan*\", NAME=\"wlan-ap\", NAME=\"wlan-ap\"" |
+              sudo tee /etc/udev/rules.d/70-persistent-net.rules
+       fi
     fi    
 fi
 

--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -184,7 +184,7 @@ if [ "$(checkModule 'WITH_EXTERNAL_WIFI')" ]; then
               sudo tee /etc/udev/rules.d/70-persistent-net.rules
        fi
        if [[ "$pinBy" == "Driver" ]]; then
-           echo "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVER==\"$driver\", ATTR{dev_id}==\"0x0\", ATTR{type}==\"1\", KERNEL==\"wlan*\", NAME=\"wlan-ap\", NAME=\"wlan-ap\"" |
+           echo "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVER==\"$driver\", ATTR{dev_id}==\"0x0\", ATTR{type}==\"1\", KERNEL==\"wlan*\", NAME=\"wlan-ap\"" |
               sudo tee /etc/udev/rules.d/70-persistent-net.rules
        fi
     fi    

--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -131,6 +131,7 @@ sudo cp "$BASE_DIR/hostapd.service" /etc/systemd/system/hostapd.service
 sudo systemctl daemon-reload
 sudo systemctl enable hostapd.service
 
+WITH_ONBOARD_WIFI=false
 # Find onboard adapter by driver and lock to wlan-ap
 for wlanfile in /sys/class/net/wlan*; do
     wlan="$(basename "$wlanfile")"
@@ -138,10 +139,38 @@ for wlanfile in /sys/class/net/wlan*; do
     driver=$(basename "$driverPath")
 #    mac="$(cat /sys/class/net/$wlan/address)"
     if [[ "$driver" == "xradio_wlan" || "$driver" == "brcm80211" || "$driver" == "brcmfmac" || "$driver" == "rtl8189fs" ]]; then
-        echo "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"$driver\", ATTR{dev_id}==\"0x0\", ATTR{type}==\"1\", KERNEL==\"wlan*\", NAME=\"wlan-ap\"" |
+    
+        askModule "WITH_ONBOARD_WIFI" "HostAP - Found an onboard WiFi. Configure it as an Access Point?" "n"
+        if [ "$(checkModule 'WITH_ONBOARD_WIFI')" ]; then
+            echo "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"$driver\", ATTR{dev_id}==\"0x0\", ATTR{type}==\"1\", KERNEL==\"wlan*\", NAME=\"wlan-ap\"" |
                 sudo tee /etc/udev/rules.d/70-persistent-net.rules
+        fi
     fi
 done
+
+if [ ! "$(checkModule 'WITH_ONBOARD_WIFI')" ]; then
+    askModule "WITH_EXTERNAL_WIFI" "HostAP - Configure External WiFi adapter as an Access Point?" "n"
+fi
+if [ "$(checkModule 'WITH_EXTERNAL_WIFI')" ]; then
+    OPTION=""
+    i=0
+    for wlanfile in /sys/class/net/wlan*; do
+        wlan="$(basename "$wlanfile")"        
+        mac="$(cat /sys/class/net/$wlan/address)"
+        i=$((i+1))
+        MAC[$i]=$mac
+        OPTION="${OPTION} \\n $i $mac"
+    done
+    askSelection "Select Adapter MAC to pin" "$OPTION"
+    mac="${MAC[$dialogREPLY]}"
+    if [ -z "$mac" ]; then
+        echo "Error unknown response $dialogREPLY"
+        exit
+    else
+       echo "SUBSYSTEM==\"net\", ACTION==\"add\", ATTR{address}==\"$mac\", ATTR{dev_id}==\"0x0\", ATTR{type}==\"1\", KERNEL==\"wlan*\", NAME=\"wlan-ap\"" |
+          sudo tee /etc/udev/rules.d/70-persistent-net.rules
+    fi    
+fi
 
 # dnsmasq for some reason won't bind to the hostapd on Orange Pi, restarting it works
 if ! grep -q dnsmasq /etc/rc.local; then

--- a/scripts/hostapd/install
+++ b/scripts/hostapd/install
@@ -131,7 +131,6 @@ sudo cp "$BASE_DIR/hostapd.service" /etc/systemd/system/hostapd.service
 sudo systemctl daemon-reload
 sudo systemctl enable hostapd.service
 
-WITH_ONBOARD_WIFI=false
 # Find onboard adapter by driver and lock to wlan-ap
 for wlanfile in /sys/class/net/wlan*; do
     wlan="$(basename "$wlanfile")"
@@ -145,6 +144,8 @@ for wlanfile in /sys/class/net/wlan*; do
             echo "SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"$driver\", ATTR{dev_id}==\"0x0\", ATTR{type}==\"1\", KERNEL==\"wlan*\", NAME=\"wlan-ap\"" |
                 sudo tee /etc/udev/rules.d/70-persistent-net.rules
         fi
+    else
+        WITH_ONBOARD_WIFI=false
     fi
 done
 

--- a/scripts/install2
+++ b/scripts/install2
@@ -21,29 +21,19 @@ sudo apt-get install -y net-tools || true
 # Get board information and set flags accordingly
 detectBoard;
 
-# Flag to identify if board can support on-board AP. Default to false.
-SUPPORT_HOSTAP=false
 # Flag to identify if board can support on-board hardware watchdog.
 SUPPORT_WATCHDOG=false
 
 case "$BOARD_MODEL" in
     orangepizero)
-        # AP is supported if board already supports XRadio
-        if lsmod | grep -q xradio_wlan; then
-            SUPPORT_HOSTAP=true
-        fi
         SUPPORT_WATCHDOG=true
     ;;
     orangepilite)
-        SUPPORT_HOSTAP=true
         SUPPORT_WATCHDOG=true
     ;;
     orangepizeroplus2-h5)
-        SUPPORT_HOSTAP=true
     ;;
     "raspberrypi3"|"raspberrypi4")
-        # Raspberry Pi 3 has on-board WiFi that can be used as an AP
-        SUPPORT_HOSTAP=true
         # Raspberry Pi 3 has hardware watchdog
         SUPPORT_WATCHDOG=true
     ;;
@@ -324,7 +314,7 @@ if [ "$(checkModule 'WITH_AD_HOC')" ]; then
 fi
 
 # WiFi Access Point on supported boards
-if [ "$SUPPORT_HOSTAP" == "true" ] && [ "$(checkModule 'WITH_WIFI_AP')" ]; then
+if [ "$(checkModule 'WITH_WIFI_AP')" ]; then
     source hostapd/install
 fi
 

--- a/scripts/install2
+++ b/scripts/install2
@@ -255,9 +255,7 @@ askModule "WITH_MESH_POINT" "Mesh Point Interface"
 if [ "$WITH_MESH_POINT" == false ]; then
     askModule "WITH_AD_HOC" "Ad-Hoc Interface"
 fi
-if [ "$SUPPORT_HOSTAP" == "true" ]; then
-    askModule "WITH_WIFI_AP" "WiFi Access Point"
-fi
+askModule "WITH_WIFI_AP" "WiFi Access Point"
 askModule "WITH_FIREWALL" "Basic Firewall"
 askModule "WITH_IPFS" "IPFS"
 if [ "$WITH_IPFS" == true ] && [ "$BOARD_FAMILY" == "Raspberry Pi" ]; then

--- a/scripts/mesh-point/mesh-point
+++ b/scripts/mesh-point/mesh-point
@@ -3,6 +3,10 @@
 function isMeshable {
     interface=`iw dev | grep phy#$1 -A 1 | grep Interface | awk '{print $2}'`
 
+    if [ "$interface" == "wlan-ap" ]; then
+        return=''
+    fi
+
     # Check to see if driver reports missing mesh point support
     if  [ -z "$(iw phy phy$1 info | grep 'mesh point')" ]; then
         result='' # Indicate interface is not meshable

--- a/scripts/mesh-point/mesh-point
+++ b/scripts/mesh-point/mesh-point
@@ -5,6 +5,7 @@ function isMeshable {
 
     if [ "$interface" == "wlan-ap" ]; then
         return=''
+	exit 0
     fi
 
     # Check to see if driver reports missing mesh point support


### PR DESCRIPTION
AP using onboard WiFi now optional
If not selected Extenral card can be used by pinning the MAC

## TODO

- [x] Fix `askSelection` - Does not like passing \n
- [x] Fix `askSelection` -  May not like return numbers 
- [x] Add `hostapd` as install-able option globally

- [x] Test on Rasbian
- [ ] Test on Armbian

## Stretch
- [ ] Convert to check all network interfaces instead of just wlan*
    - [ ]  Check for wireless folder to check if net is wireless  (reference mesh-point script)
- [x] Pin by driver instead of MAC
- [ ] Pin to position 