### PR TITLE
Raspberry Pi Watchdog Fix

### DIFF
--- a/scripts/watchdog/install
+++ b/scripts/watchdog/install
@@ -6,7 +6,7 @@ if [[ -e '/dev/watchdog' ]]; then
     sudo sed -i "/RuntimeWatchdogSec/d" /etc/systemd/system.conf
     sudo sed -i "/ShutdownWatchdogSec/d" /etc/systemd/system.conf
 
-    echo RuntimeWatchdogSec=16 | sudo tee --append  /etc/systemd/system.conf > /dev/null
+    echo RuntimeWatchdogSec=15s | sudo tee --append  /etc/systemd/system.conf > /dev/null
     echo ShutdownWatchdogSec=10min | sudo tee --append  /etc/systemd/system.conf > /dev/null
 
 fi


### PR DESCRIPTION
[@s_leonardo mentioned 16 is to high](https://matrix.to/#/!FsFLbKGMcUXEMBxZdu:tomesh.net/$15746999021293JWihi:tomesh.net?via=tomesh.net&via=matrix.org&via=phillymesh.net) for watchdog to be set in raspberry pi (fine on allwinner boards)

> it seems that 16s is to much https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=147501

Ref: https://www.raspberrypi.org/forums/viewtopic.php?f=29&t=147501






