### PR TITLE
Rewrite SED replacement to use temporary files

### DIFF
--- a/scripts/ipfs/install
+++ b/scripts/ipfs/install
@@ -96,8 +96,10 @@ sudo cp "$BASE_DIR/ipfs-swarm.sh" /usr/local/bin/
 sudo chmod +x /usr/local/bin/ipfs-swarm.sh
 
 # Configure systemd to start ipfs.service on system boot
-sudo cp "$BASE_DIR/ipfs.service" /etc/systemd/system/ipfs.service
-sudo sed -i "s|__USER_HOME__|${HOME}|" /etc/systemd/system/ipfs.service
+sudo cp "$BASE_DIR/ipfs.service" /tmp/ipfs.service
+sudo sed -i "s|__USER_HOME__|${HOME}|" /tmp/ipfs.service
+sudo mv /tmp/ipfs.service /etc/systemd/system/ipfs.service
+
 sudo systemctl daemon-reload
 sudo systemctl enable ipfs.service
 sudo systemctl start ipfs.service

--- a/scripts/mesh-adhoc/install
+++ b/scripts/mesh-adhoc/install
@@ -9,9 +9,9 @@ MESH_NAME=$(confget -f /etc/mesh.conf -s general "mesh-name")
 sudo apt-get install -y iw 
 
 # Install bring-up script for the Mesh Ad-hoc interface to /usr/bin
-cp "$BASE_DIR/mesh-adhoc" "$BASE_DIR/mesh-adhoc2"
-sed -i "s/MESH_NAME/$MESH_NAME/g" "$BASE_DIR/mesh-adhoc2"
-sudo mv "$BASE_DIR/mesh-adhoc2" /usr/bin/mesh-adhoc
+cp "$BASE_DIR/mesh-adhoc" "/tmp/mesh-adhoc"
+sed -i "s/MESH_NAME/$MESH_NAME/g" "/tmp/mesh-adhoc"
+sudo mv "/tmp/mesh-adhoc" "/usr/bin/mesh-adhoc"
 
 # Configure systemd to start mesh-adhoc.service on system boot
 sudo cp "$BASE_DIR/mesh-adhoc.service" /etc/systemd/system/mesh-adhoc.service

--- a/scripts/shared/nodeinfo/install
+++ b/scripts/shared/nodeinfo/install
@@ -11,14 +11,15 @@ sudo apt-get install -y jq
 
 sudo mkdir -p /opt/tomesh/nodeinfo.d
 
-sudo cp "$BASE_DIR/nodeinfo.json" /opt/tomesh/nodeinfo.json
+sudo cp "$BASE_DIR/nodeinfo.json" /tmp/nodeinfo.json
 sudo cp "$BASE_DIR/nodeinfo-update.sh" /usr/local/bin/nodeinfo-update.sh
 
-sudo sed -i -e "s/__REPO__/$(git remote get-url origin | awk -F / '{print $5}'| cut -d '.' -f1)/g" /opt/tomesh/nodeinfo.json
-sudo sed -i -e "s/__BRANCH__/$(git rev-parse --abbrev-ref HEAD)/g" /opt/tomesh/nodeinfo.json
-sudo sed -i -e "s/__COMMIT__/$(git rev-parse HEAD)/g" /opt/tomesh/nodeinfo.json
-sudo sed -i -e "s/__INSTALLED__/$(date)/g" /opt/tomesh/nodeinfo.json
-sudo sed -i -e "s/__ORG__/$MESH_NAME/g" /opt/tomesh/nodeinfo.json
+sudo sed -i -e "s/__REPO__/$(git remote get-url origin | awk -F / '{print $5}'| cut -d '.' -f1)/g" /tmp/nodeinfo.json
+sudo sed -i -e "s/__BRANCH__/$(git rev-parse --abbrev-ref HEAD)/g" /tmp/nodeinfo.json
+sudo sed -i -e "s/__COMMIT__/$(git rev-parse HEAD)/g" /tmp/nodeinfo.json
+sudo sed -i -e "s/__INSTALLED__/$(date)/g" /tmp/nodeinfo.json
+sudo sed -i -e "s/__ORG__/$MESH_NAME/g" /tmp/nodeinfo.json
+sudo mv /tmp/nodeinfo.json /opt/tomesh/nodeinfo.json
 
 ##TODO## Fix rc.local issue
 sudo sed -i 's#^exit 0#/usr/local/bin/nodeinfo-update.sh\nexit 0#' /etc/rc.local || true

--- a/scripts/ssb-web-pi/install
+++ b/scripts/ssb-web-pi/install
@@ -29,8 +29,9 @@ ssbPath="$HOME/.ssb"
 currentUser=$USER
 sudo cp "$BASE_DIR/ssb-web-pi-broadcast-service.sh" "/usr/local/bin/ssb-web-pi-broadcast-service.sh"
 sudo chmod a+x "/usr/local/bin/ssb-web-pi-broadcast-service.sh"
-sudo cp "$BASE_DIR/ssb-web-pi-broadcast.service" /etc/systemd/system/ssb-web-pi-broadcast.service
-sudo sed -i "s|__USER__|${currentUser}|g" /etc/systemd/system/ssb-web-pi-broadcast.service
+sudo cp "$BASE_DIR/ssb-web-pi-broadcast.service" /tmp/ssb-web-pi-broadcast.service
+sudo sed -i "s|__USER__|${currentUser}|g" /tmp/ssb-web-pi-broadcast.service
+sudo mv /tmp/ssb-web-pi-broadcast.service /etc/systemd/system/ssb-web-pi-broadcast.service
 
 sudo systemctl daemon-reload
 sudo systemctl enable ssb-web-pi-broadcast.service


### PR DESCRIPTION
To prevent config files in a undesired state, copy file to tmp folder, then use sed on those files before moving them to final place.