### PR TITLE
Update NodeJS to latest LTS (12.16.2)

### DIFF
--- a/scripts/shared/node.js/install
+++ b/scripts/shared/node.js/install
@@ -2,18 +2,18 @@
 
 set -e
 
-NODEJS_PREFIX=10
-NODEJS_VERSION="$NODEJS_PREFIX.15.3"
+NODEJS_PREFIX=12
+NODEJS_VERSION="$NODEJS_PREFIX.16.2"
 
 # Check whether it has the newest version - 32-bit OSes need an older one
 if [[ ("$(node --version)" != "v$NODEJS_VERSION") || ("$(uname -m)" =~ ^(i386|i586|i686)$ && "$(node --version)" != "v8.11.0") ]]; then
-    # Check for armv6 and install NodeJS manually instead since it will not install via repo
+    # Check for armv6 and install an older LTS since 12 and later don't support this arch
     if uname -m | grep -Eq ^armv6; then
-        wget -O /tmp/node-v$NODEJS_VERSION-linux-armv6l.tar.gz https://nodejs.org/dist/v$NODEJS_VERSION/node-v$NODEJS_VERSION-linux-armv6l.tar.gz
-        sudo tar xfz /tmp/node-v$NODEJS_VERSION-linux-armv6l.tar.gz --strip 1 -C /
-        rm -rf /tmp/node-v$NODEJS_VERSION-linux-armv6l.tar.gz
+        wget -O /tmp/node-v10.20.0-linux-armv6l.tar.gz https://nodejs.org/dist/v10.20.0/node-v10.20.0-linux-armv6l.tar.gz
+        sudo tar xfz /tmp/node-v10.20.0-linux-armv6l.tar.gz --strip 1 -C /
+        rm -rf /tmp/node-v10.20.0-linux-armv6l.tar.gz
         sudo ln -s /bin/node /bin/nodejs
-    # Check if it's 32-bit and install the previous NodeJS LTS since 10 doesn't support this arch
+    # Check if it's 32-bit and install the previous NodeJS LTS since 10 and later doesn't support this arch
     elif [[ "$(uname -m)" =~ ^(i386|i586|i686)$ ]]; then
         wget -O /tmp/node-v8.16.0-linux-x86.tar.gz https://nodejs.org/dist/v8.11.0/node-v8.11.0-linux-x86.tar.gz
         sudo tar xfz /tmp/node-v8.11.0-linux-x86.tar.gz --strip 1 -C /


### PR DESCRIPTION
This is a small PR, but the biggest change is that `armv6` is left behind. NodeJS no longer supports it, and so I've set it up to download the 10.x LTS instead. Should we be compiling our own versions of NodeJS for armv6 and 32-bit arches, which are stuck on the 8.x LTS? I opened #484 to talk about that. For now I think this can be merged.